### PR TITLE
Caching path fix

### DIFF
--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -1,6 +1,5 @@
-from itertools import zip_longest
 from logging import debug
-from glob import iglob
+import pathlib
 import json
 import copy
 import os
@@ -14,11 +13,13 @@ def cache_specs(basedir):
     YAML parsing is incredibly slow, and JSON is quite fast,
     so we check modification times and convert any that have changed.
     """
-    os.makedirs(os.path.join(basedir, '_cache'), exist_ok=True)
-    yaml_specs = iglob(os.path.join(basedir, '*.yaml'))
-    json_specs = iglob(os.path.join(basedir, '_cache', '*.json'))
+    basedir = pathlib.Path(basedir)
 
-    for yamlfile, jsonfile in zip_longest(yaml_specs, json_specs):
+    cachedir = pathlib / '_cache'
+    cachedir.mkdir(exist_ok=True)
+
+    for yamlfile in basedir.glob('*.yaml'):
+        jsonfile = cachedir / yamlfile.with_suffix('.json')
         cache_spec(source_file=yamlfile, dest_file=jsonfile)
 
 

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -24,18 +24,6 @@ def cache_specs(basedir):
 
 
 def cache_spec(*, source_file, dest_file):
-    if not source_file:
-        # If yamlfile doesn't exist, then because we used zip_longest
-        # there has to be a jsonfile. We don't want any jsonfiles
-        # that don't match the yamlfiles.
-        os.remove(dest_file)
-        return
-
-    if not dest_file:
-        dest_file = source_file \
-            .replace('specs/', 'specs/_cache/') \
-            .replace('.yaml', '.json')
-
     source_modtime = get_modification_time_ns(source_file)
     dest_modtime = get_modification_time_ns(dest_file)
 

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -15,7 +15,7 @@ def cache_specs(basedir):
     """
     basedir = pathlib.Path(basedir)
 
-    cachedir = pathlib / '_cache'
+    cachedir = basedir / '_cache'
     cachedir.mkdir(exist_ok=True)
 
     for yamlfile in basedir.glob('*.yaml'):


### PR DESCRIPTION
Closes #107 

I don't think the issue here is a huge issue, but I think it does potentially exist.

The issue I tried to describe in #107 is that, in certain cases, I think a yaml file could be cached under the wrote JSON filename.

With this patch, we only ever look at the yaml files, so we can't possibly store the json under the wrong name.