### PR TITLE
Additions to spec options

### DIFF
--- a/stograde/specs/__init__.py
+++ b/stograde/specs/__init__.py
@@ -2,3 +2,4 @@ from .load import load_all_specs
 from .load import load_some_specs
 from .util import get_filenames
 from .util import check_dependencies
+from .util import check_architecture

--- a/stograde/specs/util.py
+++ b/stograde/specs/util.py
@@ -21,7 +21,8 @@ def check_dependencies(spec):
 def check_architecture(assignment, spec, ci):
     # get check_architecture()
     _, arch, _ = run(['uname', '-m'])
-    if spec.get('architecture', None) == arch:
+    spec_arch = spec.get('architecture', None)
+    if not spec_arch or spec_arch == arch:
         return True
     else:
         if ci:

--- a/stograde/specs/util.py
+++ b/stograde/specs/util.py
@@ -1,5 +1,8 @@
 import os
-from logging import warning
+import logging
+import sys
+
+from stograde.common import run
 
 
 def get_filenames(spec):
@@ -12,4 +15,22 @@ def check_dependencies(spec):
         try:
             os.stat(filepath)
         except FileNotFoundError:
-            warning('spec {}: required file "{}" could not be found'.format(spec['assignment'], filepath))
+            logging.warning('spec {}: required file "{}" could not be found'.format(spec['assignment'], filepath))
+
+
+def check_architecture(assignment, spec, ci):
+    # get check_architecture()
+    _, arch, _ = run(['uname', '-m'])
+    try:
+        if spec['architecture'] != arch:
+            if ci:
+                logging.info('Skipping {}: wrong architecture'.format(assignment))
+            else:
+                print('{} requires {} architecture. You have {}'
+                      .format(assignment, spec['architecture'], arch),
+                      file=sys.stderr)
+            return False
+        else:
+            return True
+    except KeyError:
+        return True

--- a/stograde/specs/util.py
+++ b/stograde/specs/util.py
@@ -21,16 +21,13 @@ def check_dependencies(spec):
 def check_architecture(assignment, spec, ci):
     # get check_architecture()
     _, arch, _ = run(['uname', '-m'])
-    try:
-        if spec['architecture'] != arch:
-            if ci:
-                logging.info('Skipping {}: wrong architecture'.format(assignment))
-            else:
-                print('{} requires {} architecture. You have {}'
-                      .format(assignment, spec['architecture'], arch),
-                      file=sys.stderr)
-            return False
-        else:
-            return True
-    except KeyError:
+    if spec.get('architecture', None) == arch:
         return True
+    else:
+        if ci:
+            logging.info('Skipping {}: wrong architecture'.format(assignment))
+        else:
+            print('{} requires {} architecture. You have {}'
+                  .format(assignment, spec['architecture'], arch),
+                  file=sys.stderr)
+        return False

--- a/stograde/specs/util.py
+++ b/stograde/specs/util.py
@@ -22,7 +22,7 @@ def check_architecture(assignment, spec, ci):
     # get check_architecture()
     _, arch, _ = run(['uname', '-m'])
     spec_arch = spec.get('architecture', None)
-    if not spec_arch or spec_arch == arch:
+    if spec_arch is None or spec_arch == arch:
         return True
     else:
         if ci:

--- a/stograde/student/markdownify/add_remove_supporting.py
+++ b/stograde/student/markdownify/add_remove_supporting.py
@@ -1,0 +1,34 @@
+import os
+
+
+def import_supporting(*, spec, spec_id, basedir):
+    cwd = os.getcwd()
+    inputs = spec.get('inputs', [])
+    supporting_dir = os.path.join(basedir, 'data', 'supporting')
+    written_files = []
+    # write the supporting files into the folder
+    for filename in inputs:
+        if isinstance(filename, list):
+            if len(filename) == 1:
+                in_name = filename[0]
+                out_name = filename[0]
+            else:
+                in_name = filename[0]
+                out_name = filename[1]
+        else:
+            in_name = filename
+            out_name = filename
+        with open(os.path.join(supporting_dir, spec_id, in_name), 'rb') as infile:
+            contents = infile.read()
+        with open(os.path.join(cwd, out_name), 'wb') as outfile:
+            outfile.write(contents)
+            written_files.append(out_name)
+    return supporting_dir, written_files
+
+
+def remove_supporting(written_files):
+    try:
+        for inputfile in written_files:
+            os.remove(inputfile)
+    except FileNotFoundError:
+        pass

--- a/stograde/student/markdownify/markdownify.py
+++ b/stograde/student/markdownify/markdownify.py
@@ -3,7 +3,7 @@
 import os
 from collections import OrderedDict
 
-from .add_remove_supporting import import_supporting, remove_supporting
+from .supporting import import_supporting, remove_supporting
 from .process_file import process_file
 from .find_warnings import find_warnings
 from ...common import check_dates

--- a/stograde/student/markdownify/markdownify.py
+++ b/stograde/student/markdownify/markdownify.py
@@ -2,6 +2,8 @@
 
 import os
 from collections import OrderedDict
+
+from .add_remove_supporting import import_supporting, remove_supporting
 from .process_file import process_file
 from .find_warnings import find_warnings
 from ...common import check_dates
@@ -26,15 +28,9 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_w
         }
 
         # prepare the current folder
-        inputs = spec.get('inputs', [])
-        supporting = os.path.join(basedir, 'data', 'supporting')
-        # write the supporting files into the folder
-        for filename in inputs:
-            with open(os.path.join(supporting, spec_id, filename), 'rb') as infile:
-                contents = infile.read()
-            with open(os.path.join(cwd, filename), 'wb') as outfile:
-                outfile.write(contents)
-
+        supporting_dir, written_files = import_supporting(spec=spec,
+                                                          spec_id=spec_id,
+                                                          basedir=basedir)
         for file in spec['files']:
             filename = file['filename']
             steps = file['commands']
@@ -44,7 +40,7 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_w
                                   options=options,
                                   spec=spec,
                                   cwd=cwd,
-                                  supporting_dir=supporting,
+                                  supporting_dir=supporting_dir,
                                   interact=interact,
                                   basedir=basedir,
                                   spec_id=spec_id,
@@ -52,18 +48,10 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_w
             results['files'][filename] = result
 
         # now we remove any compiled binaries
-        try:
-            for file in spec['files']:
-                os.remove('{}.exec'.format(file['filename']))
-        except FileNotFoundError:
-            pass
+        remove_execs(spec)
 
         # and we remove any supporting files
-        try:
-            for inputfile in inputs:
-                os.remove(inputfile)
-        except FileNotFoundError:
-            pass
+        remove_supporting(written_files)
 
         return results
 
@@ -77,3 +65,11 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_w
                 'Recording error': str(err),
             },
         }
+
+
+def remove_execs(spec):
+    try:
+        for file in spec['files']:
+            os.remove('{}.exec'.format(file['filename']))
+    except FileNotFoundError:
+        pass

--- a/stograde/student/markdownify/supporting.py
+++ b/stograde/student/markdownify/supporting.py
@@ -6,6 +6,7 @@ def import_supporting(*, spec, spec_id, basedir):
     inputs = spec.get('inputs', [])
     supporting_dir = os.path.join(basedir, 'data', 'supporting')
     written_files = []
+
     # write the supporting files into the folder
     for filename in inputs:
         if isinstance(filename, list):
@@ -18,11 +19,13 @@ def import_supporting(*, spec, spec_id, basedir):
         else:
             in_name = filename
             out_name = filename
+
         with open(os.path.join(supporting_dir, spec_id, in_name), 'rb') as infile:
             contents = infile.read()
         with open(os.path.join(cwd, out_name), 'wb') as outfile:
             outfile.write(contents)
             written_files.append(out_name)
+
     return supporting_dir, written_files
 
 

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -10,7 +10,7 @@ import logging
 from .ci_analyze import ci_analyze
 from ..student import clone_student
 from ..common import chdir, run
-from ..specs import load_all_specs, check_dependencies
+from ..specs import load_all_specs, check_dependencies, check_architecture
 from .find_update import update_available
 from .process_student import process_student
 from .args import process_args, compute_stogit_url
@@ -174,6 +174,8 @@ def main():
         for spec_to_use in assignments:
             try:
                 check_dependencies(specs[spec_to_use])
+                if not check_architecture(spec_to_use, specs[spec_to_use], ci):
+                    available_specs.remove(spec_to_use)
             except KeyError:
                 # Prevent lab0 directory from causing an extraneous output
                 if spec_to_use != 'lab0':


### PR DESCRIPTION
Allow the architecture to be specified for an assignment using `architecture: armv7l`, for example
Allow the output name for a supporting file to be specified, i.e. using `[ 'input', 'output' ]`.
(Specifying a single name or not putting it in an array will have the same behavior as before.)