### PR TITLE
Catch error when 'files' not in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ installs into your home folder, instead.
 
 ##### Grab the course specs
 
-If grading for Software Design, Hardware Design or Algorithms and Data Structures, the toolkit will automatically
+If grading for Software Design, Hardware Design, Algorithms and Data Structures or Operating Systems, the toolkit will automatically
 download the specs for the course if they are not present and the `--course` flag is set.
 
 If you want to grab the course specs yourself, you can clone the specs (make sure you're still in the directory you

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -15,8 +15,14 @@ def cache_specs(basedir):
     so we check modification times and convert any that have changed.
     """
     os.makedirs(os.path.join(basedir, '_cache'), exist_ok=True)
+
     yaml_specs = iglob(os.path.join(basedir, '*.yaml'))
+    yaml_specs = [spec for spec in yaml_specs]
+    yaml_specs.sort()
+
     json_specs = iglob(os.path.join(basedir, '_cache', '*.json'))
+    json_specs = [spec for spec in json_specs]
+    json_specs.sort()
 
     for yamlfile, jsonfile in zip_longest(yaml_specs, json_specs):
         cache_spec(source_file=yamlfile, dest_file=jsonfile)

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -64,8 +64,9 @@ def convert_spec(yaml_path, json_path):
 
 def clarify_yaml(data):
     copied = copy.deepcopy(data)
-    copied['files'] = [process_filelike_into_dict(f) for f in copied['files']]
-    if 'tests' in copied:
+    if 'files' in copied and copied['files'] is not None:
+        copied['files'] = [process_filelike_into_dict(f) for f in copied['files']]
+    if 'tests' in copied and copied['tests'] is not None:
         copied['tests'] = [process_filelike_into_dict(f) for f in copied['tests']]
     return copied
 

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -219,7 +219,8 @@ def main():
         do_record = True
 
         if web:
-            spec = specs[list(assignments)[0]]
+            spec_id = list(assignments)[0]
+            spec = specs[spec_id]
             web_spec = check_web_spec(spec)
             if not web_spec:
                 print("No web files in assignment {}".format(list(assignments)[0]))
@@ -234,6 +235,7 @@ def main():
                                    date=date,
                                    no_update=no_update,
                                    spec=spec,
+                                   spec_id=spec_id,
                                    usernames=usernames)
             if not do_record:
                 quiet = True

--- a/stograde/webapp/web_cli.py
+++ b/stograde/webapp/web_cli.py
@@ -23,7 +23,7 @@ def check_student(student, spec, spec_id, basedir):
                                       options=file['options'],
                                       spec=spec,
                                       cwd=os.getcwd(),
-                                      supporting_dir=os.path.join(basedir, 'data', 'supporting'),
+                                      supporting_dir=supporting_dir,
                                       interact=False,
                                       basedir=basedir,
                                       spec_id=spec['assignment'],
@@ -71,7 +71,7 @@ def ask_student(usernames):
     return student['student']
 
 
-def ask_file(files, student, spec, basedir):
+def ask_file(files, student, spec, spec_id, basedir):
     style = style_from_dict({
         Token.QuestionMark: '#e3bd27 bold',
         Token.Selected: '#e3bd27',
@@ -99,30 +99,23 @@ def ask_file(files, student, spec, basedir):
             if file_spec:
                 with chdir('{}/{}'.format(student, spec['assignment'])):
                     # prepare the current folder
-                    inputs = spec.get('inputs', [])
-                    supporting = os.path.join(basedir, 'data', 'supporting')
-                    # write the supporting files into the folder
-                    for filename in inputs:
-                        with open(os.path.join(supporting, spec['assignment'], filename), 'rb') as infile:
-                            contents = infile.read()
-                        with open(os.path.join(os.getcwd(), filename), 'wb') as outfile:
-                            outfile.write(contents)
+                    supporting_dir, written_files = import_supporting(spec=spec,
+                                                                      spec_id=spec_id,
+                                                                      basedir=basedir)
+
                     process_file(file_spec['filename'],
                                  steps=file_spec['commands'],
                                  options=file_spec['options'],
                                  spec=spec,
                                  cwd=os.getcwd(),
-                                 supporting_dir=os.path.join(basedir, 'data', 'supporting'),
+                                 supporting_dir=supporting_dir,
                                  interact=False,
                                  basedir=basedir,
                                  spec_id=spec['assignment'],
                                  skip_web_compile=False)
                     # and we remove any supporting files
-                    try:
-                        for inputfile in inputs:
-                            os.remove(inputfile)
-                    except FileNotFoundError:
-                        pass
+                    remove_supporting(written_files)
+
         else:
             return
 
@@ -153,7 +146,7 @@ def launch_cli(basedir, date, no_update, spec, spec_id, usernames):
         files = check_student(student, spec, spec_id, basedir)
 
         if files:
-            ask_file(files, student, spec, basedir)
+            ask_file(files, student, spec, spec_id, basedir)
 
 
 def check_web_spec(spec):


### PR DESCRIPTION
- Check if 'files' is in the spec before processing
- Check that 'files' and 'tests' are not empty before processing
- Fix #107 
- Update web CLI to use new supporting file functions