### PR TITLE
Remove trailing whitespace/newlines from arch to fix check

### DIFF
--- a/stograde/specs/util.py
+++ b/stograde/specs/util.py
@@ -21,6 +21,7 @@ def check_dependencies(spec):
 def check_architecture(assignment, spec, ci):
     # get check_architecture()
     _, arch, _ = run(['uname', '-m'])
+    arch = arch.rstrip()
     spec_arch = spec.get('architecture', None)
     if spec_arch is None or spec_arch == arch:
         return True


### PR DESCRIPTION
Fix an issue with the arch check where the system's arch string would have a newline which would fail the check, even on the correct architecture.