### PR TITLE
Improve readability of yaml files

### DIFF
--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -76,13 +76,40 @@ def convert_spec(yaml_path, json_path):
 def clarify_yaml(data):
     copied = copy.deepcopy(data)
     if 'files' in copied and copied['files'] is not None:
-        copied['files'] = [process_filelike_into_dict(f) for f in copied['files']]
+        copied['files'] = [process_file_yaml_into_dict(f) for f in copied['files']] \
+            if 'new_spec' in copied and copied['new_spec'] is True else \
+            [process_file_yaml_into_dict_legacy(f) for f in copied['files']]
     if 'tests' in copied and copied['tests'] is not None:
-        copied['tests'] = [process_filelike_into_dict(f) for f in copied['tests']]
+        copied['tests'] = [process_file_yaml_into_dict(f) for f in copied['tests']] \
+            if 'new_spec' in copied and copied['new_spec'] is True else \
+            [process_file_yaml_into_dict_legacy(f) for f in copied['tests']]
     return copied
 
 
-def process_filelike_into_dict(file_list):
+def process_file_yaml_into_dict(file_list):
+    filename = file_list['file']
+    if filename is None:
+        raise Exception("File name must be specified")
+
+    commands = [] if 'commands' not in file_list else \
+        [file_list['commands']] if isinstance(file_list['commands'], str) else \
+        file_list['commands'] if isinstance(file_list['commands'], list) else None
+    if commands is None:
+        raise TypeError
+
+    options = {} if 'options' not in file_list else \
+        file_list['options'] if isinstance(file_list['options'], dict) else None
+    if options is None:
+        raise TypeError
+
+    return {
+        'filename': filename,
+        'commands': commands,
+        'options': options,
+    }
+
+
+def process_file_yaml_into_dict_legacy(file_list):
     filename = file_list[0]
     commands = [f for f in file_list[1:] if isinstance(f, str)]
     option_list = [opt for opt in file_list[1:] if isinstance(opt, dict)]

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -93,12 +93,12 @@ def process_file_yaml_into_dict(file_list):
     if filename is None:
         raise Exception("File name must be specified")
 
-    commands = [] if 'commands' not in file_list else file_list['commands']
+    commands = file_list.get('commands', [])
     if isinstance(commands, str):
         commands = [commands]
     assert isinstance(commands, list)
 
-    options = {} if 'options' not in file_list else file_list['options']
+    options = file_list.get('options', {})
     assert isinstance(options, dict)
 
     return {

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -76,13 +76,15 @@ def convert_spec(yaml_path, json_path):
 def clarify_yaml(data):
     copied = copy.deepcopy(data)
     if 'files' in copied and copied['files'] is not None:
-        copied['files'] = [process_file_yaml_into_dict(f) for f in copied['files']] \
-            if 'new_spec' in copied and copied['new_spec'] is True else \
-            [process_file_yaml_into_dict_legacy(f) for f in copied['files']]
+        if copied.get('spec_version', 2) >= 3:
+            copied['files'] = [process_file_yaml_into_dict(f) for f in copied['files']]
+        else:
+            copied['files'] = [process_file_yaml_into_dict_legacy(f) for f in copied['files']]
     if 'tests' in copied and copied['tests'] is not None:
-        copied['tests'] = [process_file_yaml_into_dict(f) for f in copied['tests']] \
-            if 'new_spec' in copied and copied['new_spec'] is True else \
-            [process_file_yaml_into_dict_legacy(f) for f in copied['tests']]
+        if copied.get('spec_version', 2) >= 3:
+            copied['tests'] = [process_file_yaml_into_dict(f) for f in copied['tests']]
+        else:
+            copied['tests'] = [process_file_yaml_into_dict_legacy(f) for f in copied['tests']]
     return copied
 
 
@@ -91,16 +93,13 @@ def process_file_yaml_into_dict(file_list):
     if filename is None:
         raise Exception("File name must be specified")
 
-    commands = [] if 'commands' not in file_list else \
-        [file_list['commands']] if isinstance(file_list['commands'], str) else \
-        file_list['commands'] if isinstance(file_list['commands'], list) else None
-    if commands is None:
-        raise TypeError
+    commands = [] if 'commands' not in file_list else file_list['commands']
+    if isinstance(commands, str):
+        commands = [commands]
+    assert isinstance(commands, list)
 
-    options = {} if 'options' not in file_list else \
-        file_list['options'] if isinstance(file_list['options'], dict) else None
-    if options is None:
-        raise TypeError
+    options = {} if 'options' not in file_list else file_list['options']
+    assert isinstance(options, dict)
 
     return {
         'filename': filename,

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -105,6 +105,7 @@ def main():
     no_update = args['no_update']
     no_progress = args['no_progress']
     port = args['server_port']
+    re_cache_specs = args['re_cache']
     quiet = args['quiet']
     skip_update_check = args['skip_update_check']
     skip_web_compile = args['skip_web_compile']
@@ -153,6 +154,9 @@ def main():
                         sys.exit(1)
                 else:
                     sys.exit(1)
+
+    if re_cache_specs and os.path.exists("data/_cache"):
+        os.removedirs("data/_cache")
 
     specs = load_all_specs(basedir=os.path.join(basedir, 'data'), skip_update_check=skip_update_check)
     if not specs:

--- a/stograde/toolkit/args.py
+++ b/stograde/toolkit/args.py
@@ -63,6 +63,7 @@ def build_argparser():
                           help='Skip compilation and testing of files marked with web: true')
     optional.add_argument('--port', type=int, dest='server_port', default=25100,
                           help='Set the port for the server to use')
+    optional.add_argument('--re-cache', action='store_true', help='Force a re-caching of specs')
 
     folder = parser.add_argument_group('student management arguments')
     folder.add_argument('--clean', action='store_true',


### PR DESCRIPTION
Allow yaml files to be specified in a new format that improves readability.
Instead of using a single array to hold all information for a file or test, split parts into `file`, `commands`, `options`, like they are in the cached json.
This new format is activated by adding `spec_version: 3` to the spec.
This may make specs longer, but makes them easier to understand for those new to creating specs.

Example usage:
```yaml
---
assignment: hw1

compilers:
  - &cpp 'g++ --std=c++11 $@ -o $@.exec'
  - &server 'g++ --std=c++11 $@ $SERVER'

files:
  - [ hello.cpp, *server, web: true ]
  - [ hw1_questions.txt ]
  - [ Makefile ]
  - [ Dog.h ]
  - [ Dog.cpp ]
  - - tryDog.cpp
    - rm -f tryDog tryDog.o Dog.o
    - make

tests:
  - [ tryDog.cpp, ./tryDog ]

inputs:
  - prelude
  - postlude
  - sd_fun.h
```
becomes
```yaml
---
assignment: hw1

spec_version: 3

compilers:
  - &cpp 'g++ --std=c++11 $@ -o $@.exec'
  - &server 'g++ --std=c++11 $@ $SERVER'

files:
  - file: hello.cpp
    commands: *server
    options:
      web: true
  - file: hw1_questions.txt
  - file: Makefile
  - file: Dog.h
  - file: Dog.cpp
  - file: tryDog.cpp
    commands:
      - rm -f trydog trydog.o Dog.o
      - make

tests:
  - file: tryDog.cpp
    commands: ./tryDog

inputs:
  - prelude
  - postlude
  - sd_fun.h
```

Thoughts?