### PR TITLE
Ensure server directory exists whenever web file is compiled

### DIFF
--- a/stograde/student/markdownify/process_file.py
+++ b/stograde/student/markdownify/process_file.py
@@ -126,6 +126,9 @@ def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interac
     if not should_continue or skip_web_compile and options['web']:
         return results
 
+    if options['web']:
+        os.makedirs('{}/server'.format(basedir), exist_ok=True)
+
     should_continue = compile_file(filename,
                                    steps=steps,
                                    results=results,


### PR DESCRIPTION
If a webfile is being compiled, make sure that the server directory exists before compiling.
Currently the main method only creates it if the --web or --ci, causing compilation issues for web files when only being recorded if the directory had not been created earlier.