### PR TITLE
Spec Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,9 @@ compilers:
   - &cpp 'g++ --std=c++11 $@ -o $@.exec'
 
 files:
-  - [ types.cpp, *cpp ]
-
-tests:
-  - [ types.cpp, $@.exec ]
+  - file: types.cpp
+    commands: *cpp
+    tests: $@.exec
 ```
 
 This spec will go into the `hw2` folder and look for the `types.cpp` file. If it's not found, it'll print a warning to
@@ -287,6 +286,7 @@ optional arguments:
   --skip-web-compile    Skip compilation and testing of files marked with web:
                         true
   --port SERVER_PORT    Set the port for the server to use
+  --re-cache            Force re-caching of specs
 
 student management arguments:
   --clean               Remove student folders and re-clone them
@@ -312,7 +312,7 @@ grading arguments:
 
 
 ## Advanced Usage
-`--course {sd|hd|ads}` affects the calculation of the base Stogit URL, allowing you to use the toolkit for
+`--course {sd|hd|ads|os}` affects the calculation of the base Stogit URL, allowing you to use the toolkit for
 Hardware Design or Algorithms and Data Structures as well.
 
 `--stogit URL` lets you force the base url where the repositories are cloned from. It's passed to `git` in the form

--- a/stograde/specs/__init__.py
+++ b/stograde/specs/__init__.py
@@ -1,3 +1,4 @@
+from .cache import delete_cache
 from .load import load_all_specs
 from .load import load_some_specs
 from .util import get_filenames

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -76,55 +76,50 @@ def convert_spec(yaml_path, json_path):
 def clarify_yaml(data):
     copied = copy.deepcopy(data)
     if 'files' in copied and copied['files'] is not None:
-        if copied.get('spec_version', 2) >= 3:
-            copied['files'] = [process_file_yaml_into_dict(f) for f in copied['files']]
-        else:
-            copied['files'] = [process_file_yaml_into_dict_legacy(f) for f in copied['files']]
+        copied['files'] = [process_file_yaml_into_dict(f) for f in copied['files']]
     if 'tests' in copied and copied['tests'] is not None:
-        if copied.get('spec_version', 2) >= 3:
-            copied['tests'] = [process_file_yaml_into_dict(f) for f in copied['tests']]
-        else:
-            copied['tests'] = [process_file_yaml_into_dict_legacy(f) for f in copied['tests']]
+        copied['tests'] = [process_file_yaml_into_dict(f) for f in copied['tests']]
     return copied
 
 
 def process_file_yaml_into_dict(file_list):
-    filename = file_list['file']
-    if filename is None:
-        raise Exception("File name must be specified")
+    if isinstance(file_list, dict):
+        filename = file_list['file']
+        if filename is None:
+            raise Exception("File name must be specified")
 
-    commands = file_list.get('commands', [])
-    if isinstance(commands, str):
-        commands = [commands]
-    assert isinstance(commands, list)
+        commands = file_list.get('commands', [])
+        if isinstance(commands, str):
+            commands = [commands]
+        assert isinstance(commands, list)
 
-    tests = file_list.get('tests', [])
-    if isinstance(tests, str):
-        tests = [tests]
-    assert isinstance(tests, list)
+        tests = file_list.get('tests', [])
+        if isinstance(tests, str):
+            tests = [tests]
+        assert isinstance(tests, list)
 
-    options = file_list.get('options', {})
-    assert isinstance(options, dict)
+        options = file_list.get('options', {})
+        assert isinstance(options, dict)
 
-    return {
-        'filename': filename,
-        'commands': commands,
-        'tests': tests,
-        'options': options,
-    }
-
-
-def process_file_yaml_into_dict_legacy(file_list):
-    filename = file_list[0]
-    commands = [f for f in file_list[1:] if isinstance(f, str)]
-    option_list = [opt for opt in file_list[1:] if isinstance(opt, dict)]
-    options = {k: v for opt in option_list for k, v in opt.items()}
-    return {
-        'filename': filename,
-        'commands': commands,
-        'tests': [],
-        'options': options,
-    }
+        return {
+            'filename': filename,
+            'commands': commands,
+            'tests': tests,
+            'options': options,
+        }
+    elif isinstance(file_list, list):
+        filename = file_list[0]
+        commands = [f for f in file_list[1:] if isinstance(f, str)]
+        option_list = [opt for opt in file_list[1:] if isinstance(opt, dict)]
+        options = {k: v for opt in option_list for k, v in opt.items()}
+        return {
+            'filename': filename,
+            'commands': commands,
+            'tests': [],
+            'options': options,
+        }
+    else:
+        raise TypeError('Cannot parse spec: incorrect data type')
 
 
 def json_date_handler(obj):

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -1,3 +1,5 @@
+import shutil
+import sys
 from logging import debug
 import json
 import copy
@@ -137,3 +139,10 @@ def get_modification_time_ns(path):
         return os.stat(path).st_mtime_ns
     except Exception:
         return None
+
+
+def delete_cache(basedir, dir_name='data'):
+    try:
+        shutil.rmtree(os.path.join(basedir, dir_name, 'specs', '_cache'))
+    except OSError:
+        print('Could not remove cached specs', file=sys.stderr)

--- a/stograde/specs/cache.py
+++ b/stograde/specs/cache.py
@@ -98,12 +98,18 @@ def process_file_yaml_into_dict(file_list):
         commands = [commands]
     assert isinstance(commands, list)
 
+    tests = file_list.get('tests', [])
+    if isinstance(tests, str):
+        tests = [tests]
+    assert isinstance(tests, list)
+
     options = file_list.get('options', {})
     assert isinstance(options, dict)
 
     return {
         'filename': filename,
         'commands': commands,
+        'tests': tests,
         'options': options,
     }
 
@@ -116,6 +122,7 @@ def process_file_yaml_into_dict_legacy(file_list):
     return {
         'filename': filename,
         'commands': commands,
+        'tests': [],
         'options': options,
     }
 

--- a/stograde/student/markdownify/markdownify.py
+++ b/stograde/student/markdownify/markdownify.py
@@ -35,8 +35,10 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_w
             filename = file['filename']
             steps = file['commands']
             options = file['options']
+            tests = file['tests']
             result = process_file(filename,
                                   steps=steps,
+                                  tests=tests,
                                   options=options,
                                   spec=spec,
                                   cwd=cwd,

--- a/stograde/student/markdownify/process_file.py
+++ b/stograde/student/markdownify/process_file.py
@@ -55,10 +55,11 @@ def compile_file(filename, *, steps, results, supporting_dir, basedir, spec_id):
     return True
 
 
-def test_file(filename, *, spec, results, options, cwd, supporting_dir, interact):
-    tests = flatten([test_spec['commands']
-                     for test_spec in spec.get('tests', {})
-                     if test_spec['filename'] == filename])
+def test_file(filename, *, spec, tests, results, options, cwd, supporting_dir, interact):
+    tests = tests if spec.get('spec_version', 2) >= 3 else \
+        flatten([test_spec['commands']
+                 for test_spec in spec.get('tests', {})
+                 if test_spec['filename'] == filename])
 
     for test_cmd in tests:
         if not test_cmd:
@@ -99,9 +100,10 @@ def test_file(filename, *, spec, results, options, cwd, supporting_dir, interact
     return True
 
 
-def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interact, basedir, spec_id,
-                 skip_web_compile):
+def process_file(filename, *, steps, tests, options, spec, cwd, supporting_dir, interact, basedir,
+                 spec_id, skip_web_compile):
     steps = steps if isinstance(steps, Iterable) else [steps]
+    tests = tests if isinstance(tests, Iterable) else [tests]
 
     base_opts = {
         'timeout': 4,
@@ -141,6 +143,7 @@ def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interac
 
     test_file(filename,
               spec=spec,
+              tests=tests,
               results=results,
               options=options,
               cwd=cwd,

--- a/stograde/student/markdownify/process_file.py
+++ b/stograde/student/markdownify/process_file.py
@@ -56,10 +56,9 @@ def compile_file(filename, *, steps, results, supporting_dir, basedir, spec_id):
 
 
 def test_file(filename, *, spec, tests, results, options, cwd, supporting_dir, interact):
-    tests = tests if spec.get('spec_version', 2) >= 3 else \
-        flatten([test_spec['commands']
-                 for test_spec in spec.get('tests', {})
-                 if test_spec['filename'] == filename])
+    tests = flatten(tests + [test_spec['commands']
+                             for test_spec in spec.get('tests', {})
+                             if test_spec['filename'] == filename])
 
     for test_cmd in tests:
         if not test_cmd:

--- a/stograde/student/markdownify/process_file.py
+++ b/stograde/student/markdownify/process_file.py
@@ -139,14 +139,12 @@ def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interac
     if not should_continue or not steps or options['web']:
         return results
 
-    should_continue = test_file(filename,
-                                spec=spec,
-                                results=results,
-                                options=options,
-                                cwd=cwd,
-                                supporting_dir=supporting_dir,
-                                interact=interact)
-    if not should_continue:
-        return results
+    test_file(filename,
+              spec=spec,
+              results=results,
+              options=options,
+              cwd=cwd,
+              supporting_dir=supporting_dir,
+              interact=interact)
 
     return results

--- a/stograde/student/markdownify/supporting.py
+++ b/stograde/student/markdownify/supporting.py
@@ -16,9 +16,14 @@ def import_supporting(*, spec, spec_id, basedir):
             else:
                 in_name = filename[0]
                 out_name = filename[1]
-        else:
+        elif isinstance(filename, dict):
+            in_name = filename['file']
+            out_name = filename.get('destination', in_name)
+        elif isinstance(filename, str):
             in_name = filename
             out_name = filename
+        else:
+            raise TypeError("A supporting file in {} cannot be parsed".format(spec_id))
 
         with open(os.path.join(supporting_dir, spec_id, in_name), 'rb') as infile:
             contents = infile.read()

--- a/stograde/student/markdownify/supporting.py
+++ b/stograde/student/markdownify/supporting.py
@@ -18,7 +18,7 @@ def import_supporting(*, spec, spec_id, basedir):
                 out_name = filename[1]
         elif isinstance(filename, dict):
             in_name = filename['file']
-            out_name = filename.get('destination', in_name)
+            out_name = filename.get('destination', filename.get('dest', in_name))
         elif isinstance(filename, str):
             in_name = filename
             out_name = filename
@@ -36,7 +36,7 @@ def import_supporting(*, spec, spec_id, basedir):
 
 def remove_supporting(written_files):
     try:
-        for inputfile in written_files:
-            os.remove(inputfile)
+        for supporting_file in written_files:
+            os.remove(supporting_file)
     except FileNotFoundError:
         pass

--- a/stograde/student/markdownify/supporting.py
+++ b/stograde/student/markdownify/supporting.py
@@ -3,12 +3,12 @@ import os
 
 def import_supporting(*, spec, spec_id, basedir):
     cwd = os.getcwd()
-    inputs = spec.get('inputs', [])
+    supporting_files = spec.get('inputs', []) + spec.get('supporting', [])
     supporting_dir = os.path.join(basedir, 'data', 'supporting')
     written_files = []
 
     # write the supporting files into the folder
-    for filename in inputs:
+    for filename in supporting_files:
         if isinstance(filename, list):
             if len(filename) == 1:
                 in_name = filename[0]

--- a/stograde/student/markdownify/supporting.py
+++ b/stograde/student/markdownify/supporting.py
@@ -18,7 +18,7 @@ def import_supporting(*, spec, spec_id, basedir):
                 out_name = filename[1]
         elif isinstance(filename, dict):
             in_name = filename['file']
-            out_name = filename.get('destination', filename.get('dest', in_name))
+            out_name = filename.get('destination', in_name)
         elif isinstance(filename, str):
             in_name = filename
             out_name = filename

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -9,6 +9,7 @@ import os.path
 import logging
 
 from .ci_analyze import ci_analyze
+from ..specs import delete_cache
 from ..student import clone_student
 from ..common import chdir, run
 from ..specs import load_all_specs, check_dependencies, check_architecture
@@ -157,10 +158,7 @@ def main():
                     sys.exit(1)
 
     if re_cache_specs:
-        try:
-            shutil.rmtree(os.path.join(basedir, 'data', 'specs', '_cache'))
-        except OSError:
-            print('Could not remove cached specs', file=sys.stderr)
+        delete_cache(basedir)
 
     specs = load_all_specs(basedir=os.path.join(basedir, 'data'), skip_update_check=skip_update_check)
     if not specs:

--- a/stograde/webapp/web_cli.py
+++ b/stograde/webapp/web_cli.py
@@ -21,6 +21,7 @@ def check_student(student, spec, spec_id, basedir):
                 result = process_file(file['filename'],
                                       steps=file['commands'],
                                       options=file['options'],
+                                      tests=file['tests'],
                                       spec=spec,
                                       cwd=os.getcwd(),
                                       supporting_dir=supporting_dir,
@@ -102,10 +103,11 @@ def ask_file(files, student, spec, spec_id, basedir):
                     supporting_dir, written_files = import_supporting(spec=spec,
                                                                       spec_id=spec_id,
                                                                       basedir=basedir)
-
+                    print(file_spec)
                     process_file(file_spec['filename'],
                                  steps=file_spec['commands'],
                                  options=file_spec['options'],
+                                 tests=file_spec['tests'],
                                  spec=spec,
                                  cwd=os.getcwd(),
                                  supporting_dir=supporting_dir,

--- a/stograde/webapp/web_cli.py
+++ b/stograde/webapp/web_cli.py
@@ -103,7 +103,6 @@ def ask_file(files, student, spec, spec_id, basedir):
                     supporting_dir, written_files = import_supporting(spec=spec,
                                                                       spec_id=spec_id,
                                                                       basedir=basedir)
-                    print(file_spec)
                     process_file(file_spec['filename'],
                                  steps=file_spec['commands'],
                                  options=file_spec['options'],

--- a/test/integration_tests/fixtures/two_students_hw1/data/specs/hw1.yaml
+++ b/test/integration_tests/fixtures/two_students_hw1/data/specs/hw1.yaml
@@ -10,11 +10,13 @@ files:
   - [ second.cpp, *cpp ]
   - [ secondComment.cpp, *cpp ]
   - [ Makefile ]
-  - [ Dog.h ]
-  - [ Dog.cpp ]
-  - - tryDog.cpp
-    - rm -f tryDog tryDog.o Dog.o
-    - make
+  - file: Dog.h
+  - file: Dog.cpp
+  - file: tryDog.cpp
+    commands:
+      - rm -f tryDog tryDog.o Dog.o
+      - make
+    tests: ./tryDog
 
 tests:
   - [ hello.cpp, $@.exec ]


### PR DESCRIPTION
- Increase readability of specs by moving tests to the file under `files:` they are associated with
  - Both listing tests with the file and under a separate `tests` section can be done in the same spec, even for the same file
- `supporting` tag added
  - Same functionality as `inputs`, added to make specs clearer
  - Both `supporting` and `inputs` can be used in the same spec
- Supporting files can be specified with a dict, in addition to a string or list as before:
```yaml
supporting:
  - file1.txt                   # copy file to homework directory
  - [ file2.txt, file2a.txt ]   # copy file to homework directory with rename/relocation
  - file: file3.txt             # same as above but more verbose
    destination: file3a.txt
```

- Spec versions can now be combined, no need to differentiate with `spec_version: 3` anymore.
- Remove an extraneous guarded return that doesn't do anything anymore.