### PR TITLE
Fix StoGit URL bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'appdirs == 1.4.*',
         'python-dateutil == 2.7.*',
         'PyInquirer == 1.0.*',
+        'bidict == 0.19.*',
     ],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests', 'docs']),

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -63,7 +63,9 @@ def download_specs(course, basedir, stogit):
         print("Course {} not recognized".format(course))
         sys.exit(1)
     with chdir(basedir):
+        print('Downloading specs for {}'.format(course.upper()))
         run(['git', 'clone', url, 'data'])
+        print('Download complete')
         if not stogit:
             return compute_stogit_url(course=course, stogit=None, _now=datetime.date.today())
 

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -9,12 +9,14 @@ import os.path
 import logging
 
 from .ci_analyze import ci_analyze
+from .download_specs import create_data_dir
+from .stogit_url import compute_stogit_url
 from ..student import clone_student
 from ..common import chdir, run
 from ..specs import load_all_specs, check_dependencies, check_architecture
 from .find_update import update_available
 from .process_student import process_student
-from .args import process_args, compute_stogit_url
+from .args import process_args
 from .progress_bar import progress_bar
 from .save_recordings import save_recordings, gist_recordings
 from .tabulate import tabulate
@@ -49,27 +51,6 @@ def run_server(basedir, port):
     return
 
 
-def download_specs(course, basedir, stogit):
-    spec_urls = {
-        'sd': 'https://github.com/StoDevX/cs251-specs.git',
-        'hd': 'https://github.com/StoDevX/cs241-specs.git',
-        'ads': 'https://github.com/StoDevX/cs253-specs.git',
-        'os': 'https://github.com/StoDevX/cs273-specs.git'
-    }
-    course = course.split("/")[0].lower()
-    try:
-        url = spec_urls[course]
-    except KeyError:
-        print("Course {} not recognized".format(course))
-        sys.exit(1)
-    with chdir(basedir):
-        print('Downloading specs for {}'.format(course.upper()))
-        run(['git', 'clone', url, 'data'])
-        print('Download complete')
-        if not stogit:
-            return compute_stogit_url(course=course, stogit=None, _now=datetime.date.today())
-
-
 def run_analysis(*, no_progress=False, parallel, single_analysis, usernames, workers=1):
     results = []
     records = []
@@ -95,7 +76,7 @@ def run_analysis(*, no_progress=False, parallel, single_analysis, usernames, wor
 
 def main():
     basedir = getcwd()
-    args, usernames, assignments, stogit_url = process_args()
+    args, usernames, assignments = process_args()
     ci = args['ci']
     clean = args['clean']
     course = args['course']
@@ -130,33 +111,9 @@ def main():
         logging.debug('Checking out {}'.format(date))
 
     if not os.path.exists("data"):
-        if ci:
-            if course:
-                url = download_specs(course, basedir, stogit)
-                if not stogit:
-                    stogit_url = url
-            else:
-                print("data directory not found and no course specified")
-                sys.exit(1)
+        create_data_dir(ci, course, basedir)
 
-        else:
-            print('data directory not found', file=sys.stderr)
-            if course:
-                url = download_specs(course, basedir, stogit)
-                if not stogit:
-                    stogit_url = url
-            else:
-                download = input("Download specs? (Y/N)")
-                if download and download.lower()[0] == "y":
-                    repo = input("Which class? (SD/HD/ADS/OS)")
-                    if repo:
-                        url = download_specs(repo, basedir, stogit)
-                        if not stogit:
-                            stogit_url = url
-                    else:
-                        sys.exit(1)
-                else:
-                    sys.exit(1)
+    stogit_url = compute_stogit_url(stogit=stogit, course=course, _now=datetime.date.today())
 
     if re_cache_specs:
         try:
@@ -166,7 +123,7 @@ def main():
 
     specs = load_all_specs(basedir=os.path.join(basedir, 'data'), skip_update_check=skip_update_check)
     if not specs:
-        print('no specs loaded!')
+        print('No specs loaded!')
         sys.exit(1)
 
     if assignments:

--- a/stograde/toolkit/args.py
+++ b/stograde/toolkit/args.py
@@ -1,6 +1,5 @@
 """Deal with argument parsing for the toolkit"""
 
-import datetime
 import argparse
 import os
 import sys
@@ -16,7 +15,6 @@ from stograde.common import flatten, version, run
 from .get_students import get_students as load_students_from_file
 
 ASSIGNMENT_REGEX = re.compile(r'^(HW|LAB|WS)', re.IGNORECASE)
-COURSE_REGEX = re.compile(r'^([\w]{2,3}/[sf]\d\d)$')
 
 
 def build_argparser():
@@ -152,18 +150,6 @@ def get_assignments_from_args(*, input_items, to_record, **kwargs) -> List[str]:
     return natsorted(set(assignments))
 
 
-def compute_stogit_url(*, stogit, course, _now, **kwargs) -> str:
-    """calculate a default stogit URL, or use the specified one"""
-    if stogit:
-        return stogit
-    if re.match(COURSE_REGEX, course):
-        return 'git@stogit.cs.stolaf.edu:{}'.format(course)
-
-    semester = 's' if _now.month < 7 else 'f'
-    year = str(_now.year)[2:]
-    return 'git@stogit.cs.stolaf.edu:{}/{}{}'.format(course, semester, year)
-
-
 def process_args():
     """Process the arguments and create usable data from them"""
     parser = build_argparser()
@@ -194,14 +180,14 @@ def process_args():
 
     students = get_students_from_args(**args, _all_students=load_students_from_file())
     assignments = get_assignments_from_args(**args)
-    stogit = compute_stogit_url(**args, _now=datetime.date.today())
+    # stogit = compute_stogit_url(**args, _now=datetime.date.today())
 
     print_args(args)
     print_students(students)
     print_assignments(assignments)
-    debug("stogit URL: " + stogit)
+    # debug("stogit URL: " + stogit)
 
-    return args, students, assignments, stogit
+    return args, students, assignments #, stogit
 
 
 def print_args(args):

--- a/stograde/toolkit/download_specs.py
+++ b/stograde/toolkit/download_specs.py
@@ -1,0 +1,50 @@
+import sys
+
+from bidict import bidict
+
+from stograde.common import run, chdir
+
+SPEC_URLS = bidict({
+    'sd': 'https://github.com/StoDevX/cs251-specs.git',
+    'hd': 'https://github.com/StoDevX/cs241-specs.git',
+    'ads': 'https://github.com/StoDevX/cs253-specs.git',
+    'os': 'https://github.com/StoDevX/cs273-specs.git'
+})
+
+
+def download_specs(course, basedir):
+    course = course.split("/")[0].lower()
+    try:
+        url = SPEC_URLS[course]
+    except KeyError:
+        print("Course {} not recognized".format(course))
+        sys.exit(1)
+    with chdir(basedir):
+        print('Downloading specs for {}'.format(course.upper()))
+        run(['git', 'clone', url, 'data'])
+        print('Download complete')
+        return course
+
+
+def create_data_dir(ci, course, basedir):
+    if ci:
+        if course:
+            download_specs(course, basedir)
+        else:
+            print("data directory not found and no course specified")
+            sys.exit(1)
+
+    else:
+        print('data directory not found', file=sys.stderr)
+        if course:
+            download_specs(course, basedir)
+        else:
+            download = input("Download specs? (Y/N)")
+            if download and download.lower()[0] == "y":
+                repo = input("Which class? (SD/HD/ADS/OS)")
+                if repo:
+                    download_specs(repo, basedir)
+                else:
+                    sys.exit(1)
+            else:
+                sys.exit(1)

--- a/stograde/toolkit/stogit_url.py
+++ b/stograde/toolkit/stogit_url.py
@@ -17,7 +17,7 @@ def compute_stogit_url(*, stogit, course, _now, **kwargs) -> str:
     else:
         if not course:
             course = get_course_from_specs()
-            print('Course {} inferred from specs'.format(course.upper()))
+            print('Course {} inferred from specs'.format(course.upper()), file=sys.stderr)
         semester = 's' if _now.month < 7 else 'f'
         year = str(_now.year)[2:]
         return 'git@stogit.cs.stolaf.edu:{}/{}{}'.format(course, semester, year)

--- a/stograde/toolkit/stogit_url.py
+++ b/stograde/toolkit/stogit_url.py
@@ -1,0 +1,34 @@
+import os
+import re
+import sys
+
+from stograde.common import run, chdir
+from stograde.toolkit.download_specs import SPEC_URLS
+
+COURSE_REGEX = re.compile(r'^([\w]{2,3}/[sf]\d\d)$')
+
+
+def compute_stogit_url(*, stogit, course, _now, **kwargs) -> str:
+    """calculate a default stogit URL, or use the specified one"""
+    if stogit:
+        return stogit
+    elif re.match(COURSE_REGEX, course):
+        return 'git@stogit.cs.stolaf.edu:{}'.format(course)
+    else:
+        if not course:
+            course = get_course_from_specs()
+            print('Course {} inferred from specs'.format(course.upper()))
+        semester = 's' if _now.month < 7 else 'f'
+        year = str(_now.year)[2:]
+        return 'git@stogit.cs.stolaf.edu:{}/{}{}'.format(course, semester, year)
+
+
+def get_course_from_specs():
+    if not os.path.exists("data"):
+        print('Cannot compute course from specs', file=sys.stderr)
+        sys.exit(1)
+
+    with chdir('./data'):
+        _, res, _ = run(['git', 'config', '--get', 'remote.origin.url'])
+        return SPEC_URLS.inverse[res.rstrip()]
+

--- a/stograde/toolkit/stogit_url.py
+++ b/stograde/toolkit/stogit_url.py
@@ -30,5 +30,9 @@ def get_course_from_specs():
 
     with chdir('./data'):
         _, res, _ = run(['git', 'config', '--get', 'remote.origin.url'])
-        return SPEC_URLS.inverse[res.rstrip()]
-
+        try:
+            course = SPEC_URLS.inverse[res.rstrip()]
+        except KeyError:
+            course = 'sd'     # default to SD as last resort
+        finally:
+            return course

--- a/test/toolkit/test_args.py
+++ b/test/toolkit/test_args.py
@@ -3,8 +3,9 @@ from stograde.toolkit.args import (
     build_argparser,
     get_students_from_args,
     get_assignments_from_args,
-    compute_stogit_url,
 )
+
+from stograde.toolkit.stogit_url import compute_stogit_url
 
 
 def args(arglist):


### PR DESCRIPTION
When the data directory already has specs but a new student is added, the StoGit URL for them is messed up unless if --course is specified.
Students already with their repository cloned into students are fine because their directory exists and it updates based on that.

- Moves the StoGit URL calculation until later
- Calculates URL based on the spec repository if necessary
  - Alerts user that the toolkit is inferring the course from the specs