### PR TITLE
Add stograde drive dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,12 @@
 description-file = README.md
 
 [tool:pytest]
-addopts = --pep8 --cov=stograde --cov-report term-missing test/ -W ignore::pytest.PytestDeprecationWarning
+addopts = --flake8 --cov=stograde --cov-report term-missing test/
 markers:
   datafiles: load datafiles
-pep8ignore =
-  *.py E501
-  test_*.py E712
+flake8-max-line-length = 120
+flake8-ignore =
+  test_save_recordings.py E501 F501
 
 [coverage:report]
 exclude_lines =

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,11 @@ install_requires = [
     'appdirs == 1.4.*',
     'python-dateutil == 2.7.*',
     'PyInquirer == 1.0.*',
-    'google-api-python-client == 1.11.*',
+    # stograde drive
+    'google-api-python-client == 1.12.*',
     'google-auth-oauthlib == 0.4.*',
+    'six >= 1.13.0',  # required by google-api-core
+    'setuptools >= 40.3.0',  # required by google-auth
 ]
 
 if sys.version_info < (3, 7):

--- a/stograde/toolkit/__main__.py
+++ b/stograde/toolkit/__main__.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
 
 def main():
     base_dir = getcwd()
-    args, students, assignments = process_args()
-    command: str = args['command']
-    command_func = args['func']
+    args, students, assignments = process_args()  # Dict[str, Any], List[str], List[str]
+    command: str = args['command']  # The name of the SubCommand specified
+    command_func = args['func']  # The function associated with the SubCommand
     course: str = args['course']
     skip_dependency_check: bool = args['skip_dependency_check']
     skip_version_check: bool = args['skip_version_check']
@@ -35,10 +35,11 @@ def main():
                    'to update.').format(new_version, current_version), file=sys.stderr)
 
     if command == 'drive':
+        # command_func will be do_drive()
         command_func(students=students,
                      assignment=assignments[0],
                      args=args)
-        return
+        return  # stograde drive does not use the functionality below, so return
 
     if not skip_dependency_check:
         check_dependencies()
@@ -52,12 +53,13 @@ def main():
         create_students_dir(base_dir=base_dir)
 
     if command == 'repo':
+        # command_func will be do_repo_clean() or do_repo_update()
         command_func(students=students,
                      stogit_url=stogit_url,
                      base_dir=base_dir,
                      no_progress_bar=args['no_progress_bar'],
                      workers=args['workers'])
-        return
+        return  # stograde repo does not use the functionality below, so return
 
     if command == 'table':
         assignments = [path.split('/')[-1].split('.')[0]
@@ -83,7 +85,8 @@ def main():
             print('No specs loaded!', file=sys.stderr)
             sys.exit(1)
 
-    # Call function to handle SubCommand
+    # Call function associated with specified SubCommand
+    # command_func will be do_ci(), do_record(), do_table() or do_web()
     command_func(specs=loaded_specs,
                  students=students,
                  base_dir=base_dir,

--- a/stograde/toolkit/args.py
+++ b/stograde/toolkit/args.py
@@ -100,7 +100,7 @@ def build_argparser():
                               help='An assignment to process')
     parser_drive.add_argument('--email', '-e', required=True,
                               help='Set the email of the group that documents are shared with '
-                                   '(e.g. hd-tas or hd-tas@stolaf.edu)')
+                                   '(e.g. hd-tas@stolaf.edu)')
 
     # Record SubParser
     parser_record = sub_parsers.add_parser('record', help="Record students' work",

--- a/stograde/toolkit/args.py
+++ b/stograde/toolkit/args.py
@@ -174,6 +174,9 @@ def process_args() -> Tuple[Dict[str, Any], List[str], List[str]]:
 
     command: str = args['command']
 
+    # Prepare assignments and students for each SubCommand, along with other necessary variables
+    # Note that the SubCommand is not run here, that is done by main() (which called this)
+
     # ci SubCommand
     if command == 'ci':
         assignments = get_ci_assignments()
@@ -181,9 +184,19 @@ def process_args() -> Tuple[Dict[str, Any], List[str], List[str]]:
         args['course'] = os.environ['CI_PROJECT_NAMESPACE']
         global_vars.CI = True
 
+    elif command == 'drive':
+        assignments = natsorted(set(args['assignments']))
+        students = get_students(args)
+        args['course'] = ''
+
     # record SubCommand
     elif command == 'record':
         assignments = natsorted(set(args['assignments']))  # Has at least one assignment (enforced by argparser)
+        students = get_students(args)
+
+    # repo SubCommand
+    elif command == 'repo':
+        assignments = []
         students = get_students(args)
 
     # table SubCommand
@@ -195,16 +208,6 @@ def process_args() -> Tuple[Dict[str, Any], List[str], List[str]]:
     elif command == 'web':
         assignments = natsorted(set(args['assignments']))  # Has only one assignment (enforced by argparser)
         students = get_students(args)
-
-    # repo SubCommand
-    elif command == 'repo':
-        assignments = []
-        students = get_students(args)
-
-    elif command == 'drive':
-        assignments = natsorted(set(args['assignments']))
-        students = get_students(args)
-        args['course'] = ''
 
     else:
         print('Sub-command must be specified', file=sys.stderr)

--- a/stograde/toolkit/args.py
+++ b/stograde/toolkit/args.py
@@ -90,12 +90,12 @@ def build_argparser():
     # CI SubParser
     parser_ci = sub_parsers.add_parser('ci', parents=[base_options, compile_options], conflict_handler='resolve',
                                        help="Check a single student's assignment as part of a CI job")
-    parser_ci.set_defaults(func=do_ci)
+    parser_ci.set_defaults(func=do_ci)  # Set function to run from subcommands.py
 
     # Drive SubParser
     parser_drive = sub_parsers.add_parser('drive', parents=[base_options, student_selection],
                                           conflict_handler='resolve', help='Manage submissions via google drive')
-    parser_drive.set_defaults(func=do_drive)
+    parser_drive.set_defaults(func=do_drive)  # Set function to run from subcommands.py
     parser_drive.add_argument('assignments', nargs=1, metavar='HW',
                               help='An assignment to process')
     parser_drive.add_argument('--email', '-e', required=True,
@@ -107,7 +107,7 @@ def build_argparser():
                                            parents=[base_options, record_options, compile_options,
                                                     repo_selection, table_options, student_selection],
                                            conflict_handler='resolve')
-    parser_record.set_defaults(func=do_record)
+    parser_record.set_defaults(func=do_record)  # Set function to run from subcommands.py
     parser_record.add_argument('assignments', nargs='+', metavar='HW',
                                help='An assignment to process')
     parser_record.add_argument('--table', '-t', action='store_true',
@@ -125,24 +125,26 @@ def build_argparser():
     repo_sub_parsers = parser_repo.add_subparsers()
     repo_sub_parsers.add_parser('clean', aliases=['reclone'], help='Remove and reclone student repositories',
                                 parents=[base_options, repo_selection, student_selection],
-                                conflict_handler='resolve').set_defaults(func=do_repo_clean)
+                                conflict_handler='resolve'
+                                ).set_defaults(func=do_repo_clean)  # Set function to run from subcommands.py
     repo_sub_parsers.add_parser('update', aliases=['clone'], help='Clone and/or update student repos',
                                 parents=[base_options, repo_selection, student_selection],
-                                conflict_handler='resolve').set_defaults(func=do_repo_update)
+                                conflict_handler='resolve'
+                                ).set_defaults(func=do_repo_update)  # Set function to run from subcommands.py
 
     # Table SubParser
     parser_table = sub_parsers.add_parser('table', help='Print an table of the assignments submitted by students',
                                           parents=[base_options, record_options, compile_options, repo_selection,
                                                    table_options, student_selection],
                                           conflict_handler='resolve')
-    parser_table.set_defaults(func=do_table)
+    parser_table.set_defaults(func=do_table)  # Set function to run from subcommands.py
 
     # Web SubParser
     parser_web = sub_parsers.add_parser('web', help='Run the CLI for grading React App files',
                                         parents=[base_options, record_options, compile_options,
                                                  repo_selection, student_selection],
                                         conflict_handler='resolve')
-    parser_web.set_defaults(func=do_web)
+    parser_web.set_defaults(func=do_web)  # Set function to run from subcommands.py
     parser_web.add_argument('assignments', nargs=1, metavar='HW',
                             help='An assignment to process')
     parser_web.add_argument('--port', type=int, required=True,

--- a/stograde/toolkit/progress_bar.py
+++ b/stograde/toolkit/progress_bar.py
@@ -8,8 +8,8 @@ CHAR = '·' if sys.stderr.encoding == 'UTF-8' else '='
 def progress_bar(size: int, current: int, message: str = ''):
     cols, _ = get_terminal_size()
 
-    filled = [CHAR for i in range(current)]
-    empty = [' ' for i in range(size - current)]
+    filled = [CHAR for _ in range(current)]
+    empty = [' ' for _ in range(size - current)]
     bar = ''.join(filled + empty)
 
     line = '[{}] {}'.format(bar, message)

--- a/test/common/test_parse_commit_msg_for_assignments.py
+++ b/test/common/test_parse_commit_msg_for_assignments.py
@@ -1,4 +1,5 @@
 from stograde.common.parse_commit_msg_for_assignments import parse_commit_msg_for_assignments
+
 sample = parse_commit_msg_for_assignments
 
 
@@ -44,7 +45,8 @@ def test_parse_commit_msg_for_assignments():
     assert sample('''first part of lab 7''') == [('lab', '7')]
     assert sample('''fix .gitignore to not ignore hw8/''') == [('hw', '8')]
     assert sample('''fix lab2 gitignore''') == [('lab', '2')]
-    assert sample('''Fixed Lab 1, compiled with the gcc compiler that comes with OS X on my local machine''') == [('lab', '1')]
+    assert sample('Fixed Lab 1, compiled with the gcc compiler that comes '
+                  'with OS X on my local machine') == [('lab', '1')]
     assert sample('''git submit partial lab8: all up to B:6-complete''') == [('lab', '8')]
     assert sample('''had extension, submitting lab5 complete''') == [('lab', '5')]
     assert sample('''homework 1''') == [('hw', '1')]
@@ -248,7 +250,9 @@ def test_parse_commit_msg_for_assignments():
     assert sample('''This is my first attempt to turn in homework 6''') == [('hw', '6')]
     assert sample('''this is my first attempt to upload homework 1''') == [('hw', '1')]
     assert sample('''This is my first attempt to upload homework 5''') == [('hw', '5')]
-    assert sample('''This is my first attempt to upload homework 7because originally my homework files were stored in the SD directory, so I moved them to hw6, and manually deleted the files on stogit through the web interface''') == [('hw', '7'), ('hw', '6')]
+    assert sample('This is my first attempt to upload homework 7because originally my homework files were stored '
+                  'in the SD directory, so I moved them to hw6, and manually deleted the files on stogit through '
+                  'the web interface') == [('hw', '7'), ('hw', '6')]
     assert sample('''This is my revision to homework 7''') == [('hw', '7')]
     assert sample('''this is my second attempt at submittiing lab 2''') == [('lab', '2')]
     assert sample('''this is my second attempt to upload homework 1''') == [('hw', '1')]

--- a/test/formatters/test_tabulate.py
+++ b/test/formatters/test_tabulate.py
@@ -2,8 +2,8 @@ import textwrap
 
 from stograde.process_assignment.assignment_status import AssignmentStatus
 from stograde.student.student_result import StudentResult
-from stograde.formatters.tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums, sort_by_hw_count, \
-    sort_by_username, tabulate, asciiify
+from stograde.formatters.tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums, \
+    sort_by_hw_count, sort_by_username, tabulate, asciiify
 
 
 def test_pad():

--- a/test/specs/test_spec.py
+++ b/test/specs/test_spec.py
@@ -109,14 +109,14 @@ def test_create_spec_with_supporting(datafiles):
     assert new_spec.id == 'hw7'
     assert new_spec.folder == 'hw7'
     assert new_spec.architecture is None
-    assert new_spec.dependencies is None
+    assert not new_spec.dependencies
     assert not new_spec.files
     assert new_spec.supporting_files
     assert len(new_spec.supporting_files) == 2
 
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures', 'create_spec'))
-def test_create_spec_with_supporting(datafiles):
+def test_create_spec_with_inputs(datafiles):
     with chdir(str(datafiles)):
         new_spec = create_spec(os.path.join(datafiles, 'spec_with_inputs.yaml'), '.')
 
@@ -130,7 +130,7 @@ def test_create_spec_with_supporting(datafiles):
 
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures', 'create_spec'))
-def test_create_spec_with_supporting(datafiles):
+def test_create_spec_with_supporting_and_inputs(datafiles):
     with chdir(str(datafiles)):
         new_spec = create_spec(os.path.join(datafiles, 'spec_with_supporting_and_inputs.yaml'), '.')
 

--- a/test/toolkit/test_config.py
+++ b/test/toolkit/test_config.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import textwrap
 from unittest import mock
 
 import pytest

--- a/test/toolkit/test_progress_bar.py
+++ b/test/toolkit/test_progress_bar.py
@@ -1,4 +1,3 @@
-import sys
 from shutil import get_terminal_size
 from unittest import mock
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py36
 
 [testenv]
 deps = pytest
-       pytest-pep8
+       pytest-flake8
        pytest-cov
        pytest-datafiles
        pyfakefs


### PR DESCRIPTION
- Add dependencies for `stograde drive`.  This prevents errors where version would be too old and then would throw an error when the program is running
- Switch from `pytest-pep8` to `pytest-flake8` for pep8 testing. `pytest-pep8` does not seem to be actively maintained and now causes errors with newer versions of `pytest`
