### PR TITLE
Alternate names

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -22,7 +22,7 @@ Add this to your path if your command line tells you it can't find `stograde`.
 This directory is located at
 
 - `~/.local/bin` on Linux
-- `~/Library/Python/3.X/bin` on maxOS, where `X` is your version (check with `python3 -V`)
+- `~/Library/Python/3.X/bin` on macOS, where `X` is your version (check with `python3 -V`)
 
 Consult Google or your local unix guru for help.
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -10,6 +10,7 @@ To jump to the explanation of a specific tag, follow the following links:
 - [`compilers:`](#Compilers)
 - [`files:`](#Files)
   - [`file:`](#Files)
+  - [`alternates:`](#Alternate-Names)
   - [`commands:`](#Compile-Steps)
   - [`tests:`](#Test-Steps)
   - [`options:` (and its child tags)](#Options)
@@ -82,6 +83,26 @@ files:
   - file: Dog.h
   - file: tryDog.cpp
 ```
+
+#### Alternate Names
+
+If a student turns in a file but it is not named properly, it will not be detected by StoGrade.
+If there is a file that multiple students have or may misname, this can be accommodated for in the spec file.
+Using the `alternates:` tag, one or more alternate names for the file can be given.
+For example:
+
+```yaml
+files:
+  - file: Dog.cpp
+    alternates: dog.cpp
+  - file: Dog.h
+    alternates:
+      - dog.h
+      - cat.h
+```
+
+If alternate names are given and more than one name has a matching file, then a warning will be printed in the recording alerting the grader that the file the student intended to turn in may not be the one shown in the recording.
+
 
 #### Compile Steps
 

--- a/stograde/formatters/html.py
+++ b/stograde/formatters/html.py
@@ -90,7 +90,12 @@ def format_file(file_info: 'FileResult') -> str:
     else:
         last_modified = ''
 
-    file_header = '<h2><code>{}</code>{}</h2>\n'.format(file_info.file_name, last_modified)
+    if file_info.actual_name is not None:
+        file_header = '<h2><code>{}</code> (alternate name for <code>{}</code>){}</h2>\n'.format(file_info.actual_name,
+                                                                                                 file_info.file_name,
+                                                                                                 last_modified)
+    else:
+        file_header = '<h2><code>{}</code>{}</h2>\n'.format(file_info.file_name, last_modified)
 
     if file_info.file_missing:
         note = '<p>File not found. <code>ls .</code> says that these files exist:</p>'

--- a/stograde/formatters/html.py
+++ b/stograde/formatters/html.py
@@ -107,6 +107,9 @@ def format_file(file_info: 'FileResult') -> str:
 
         return '\n'.join([file_header, note, directory_listing + '\n\n'])
 
+    if file_info.other_files:
+        file_header = file_header + "<i>Alternate files detected:</i>\n" + format_as_ul(file_info.other_files) + '\n'
+
     return '\n'.join([file_header, contents, compilation, test_results])
 
 

--- a/stograde/formatters/markdown.py
+++ b/stograde/formatters/markdown.py
@@ -106,6 +106,9 @@ def format_file(file_info: 'FileResult') -> str:
 
         return '\n'.join([file_header, note, directory_listing])
 
+    if file_info.other_files:
+        file_header = file_header + '*Alternate files detected:*\n- ' + '\n- '.join(file_info.other_files) + '\n'
+
     return '\n'.join([file_header, contents, compilation, test_results])
 
 

--- a/stograde/formatters/markdown.py
+++ b/stograde/formatters/markdown.py
@@ -89,7 +89,12 @@ def format_file(file_info: 'FileResult') -> str:
     else:
         last_modified = ''
 
-    file_header = '## {}{}\n'.format(file_info.file_name, last_modified)
+    if file_info.actual_name is not None:
+        file_header = '## {} (alternate name for {}){}\n'.format(file_info.actual_name,
+                                                                 file_info.file_name,
+                                                                 last_modified)
+    else:
+        file_header = '## {}{}\n'.format(file_info.file_name, last_modified)
 
     if file_info.file_missing:
         note = 'File not found. `ls .` says that these files exist:'

--- a/stograde/process_assignment/process_assignment.py
+++ b/stograde/process_assignment/process_assignment.py
@@ -65,7 +65,7 @@ def process_assignment(*,
 def remove_execs(spec: 'Spec'):
     """Remove executable files (identified by a .exec extension)"""
     for file in spec.files:
-        for name in [file.file_name] + file.alternate_names:
+        for name in [file.file_name, *file.alternate_names]:
             try:
                 os.remove('{}.exec'.format(name))
             except FileNotFoundError:

--- a/stograde/process_assignment/process_assignment.py
+++ b/stograde/process_assignment/process_assignment.py
@@ -65,7 +65,8 @@ def process_assignment(*,
 def remove_execs(spec: 'Spec'):
     """Remove executable files (identified by a .exec extension)"""
     for file in spec.files:
-        try:
-            os.remove('{}.exec'.format(file.file_name))
-        except FileNotFoundError:
-            pass
+        for name in [file.file_name] + file.alternate_names:
+            try:
+                os.remove('{}.exec'.format(name))
+            except FileNotFoundError:
+                pass

--- a/stograde/process_file/file_result.py
+++ b/stograde/process_file/file_result.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 class FileResult:
     """The results from compiling and testing an assignment file"""
     file_name: str  # Name of the file
+    actual_name: Optional[str] = None  # Name of the file that was found (if it was an alternate name)
     contents: str = ''  # Contents of the file
     compile_results: List['CompileResult'] = field(default_factory=list)  # Results of each compilation
     test_results: List['TestResult'] = field(default_factory=list)  # Results of each test

--- a/stograde/process_file/file_result.py
+++ b/stograde/process_file/file_result.py
@@ -16,7 +16,7 @@ class FileResult:
     test_results: List['TestResult'] = field(default_factory=list)  # Results of each test
     file_missing: bool = False  # Is the file missing
     last_modified: str = ''  # Last modification date according to git
-    other_files: List[str] = field(default_factory=list)  # Other files in the directory (used if file is missing)
+    other_files: List[str] = field(default_factory=list)  # Other files present (if missing or alternates found)
     optional: bool = False  # Is the file not required to exist
     compile_optional: bool = False  # Is the file not required to compile
     truncated_after: Optional[int] = None  # How much were the file contents truncated

--- a/stograde/process_file/process_file.py
+++ b/stograde/process_file/process_file.py
@@ -18,6 +18,14 @@ def get_file(file_spec: 'SpecFile', file_result: FileResult) -> bool:
     If the file doesn't exist, find what other files are present.
     """
     file_status, file_contents = cat(file_spec.file_name, hide_contents=file_spec.options.hide_contents)
+    print("1f: {}; a: {}".format(file_result.file_name, file_result.actual_name))
+    if file_status is not RunStatus.SUCCESS and file_spec.alternate_names:
+        for file_name in file_spec.alternate_names:
+            file_status, file_contents = cat(file_name, hide_contents=file_spec.options.hide_contents)
+            if file_status is RunStatus.SUCCESS:
+                file_result.actual_name = file_name
+                break
+    print("2f: {}; a: {}".format(file_result.file_name, file_result.actual_name))
 
     if file_status is not RunStatus.SUCCESS:
         file_result.file_missing = True
@@ -29,7 +37,10 @@ def get_file(file_spec: 'SpecFile', file_result: FileResult) -> bool:
         file_result.contents = truncate(file_contents, file_spec.options.truncate_contents)
         if file_result.contents != file_contents:
             file_result.contents_truncated_after = file_spec.options.truncate_contents
-        file_result.last_modified, _ = get_modification_time(file_spec.file_name, os.getcwd(), ModificationTime.LATEST)
+        file_result.last_modified, _ = get_modification_time(
+            file_result.file_name if file_result.actual_name is None else file_result.actual_name,
+            os.getcwd(),
+            ModificationTime.LATEST)
         return True
 
 
@@ -42,7 +53,7 @@ def parse_command(command: str, *, file_name: str, supporting_dir: str) -> str:
 def compile_file(*, file_spec: 'SpecFile', results: FileResult, supporting_dir: str) -> bool:
     for command in file_spec.compile_commands:
         command = parse_command(command,
-                                file_name=file_spec.file_name,
+                                file_name=results.file_name if results.actual_name is None else results.actual_name,
                                 supporting_dir=supporting_dir)
 
         cmd, input_for_cmd = pipe(command)
@@ -73,7 +84,8 @@ def test_file(*,
             continue
 
         command = parse_command(command,
-                                file_name=file_spec.file_name,
+                                file_name=file_results.file_name
+                                if file_results.actual_name is None else file_results.actual_name,
                                 supporting_dir=supporting_dir)
 
         test_cmd, input_for_test = pipe(command)

--- a/stograde/specs/file_options.py
+++ b/stograde/specs/file_options.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class FileOptions:
+    """Represents options available for files in specs"""
     compile_optional: bool = False
     hide_contents: bool = False
     optional: bool = False

--- a/stograde/specs/spec.py
+++ b/stograde/specs/spec.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class Spec:
+    """Represents an assignment to be checked"""
     id: str
     folder: str
     architecture: Optional[str]

--- a/stograde/specs/spec_file.py
+++ b/stograde/specs/spec_file.py
@@ -6,6 +6,7 @@ from .file_options import FileOptions
 
 @dataclass
 class SpecFile:
+    """Represents a file to be checked as part of an assignment"""
     file_name: str
     alternate_names: List[str] = field(default_factory=list)
     compile_commands: List[str] = field(default_factory=list)

--- a/stograde/specs/spec_file.py
+++ b/stograde/specs/spec_file.py
@@ -7,6 +7,7 @@ from .file_options import FileOptions
 @dataclass
 class SpecFile:
     file_name: str
+    alternate_names: List[str] = field(default_factory=list)
     compile_commands: List[str] = field(default_factory=list)
     test_commands: List[str] = field(default_factory=list)
     options: FileOptions = field(default_factory=FileOptions)
@@ -65,6 +66,11 @@ def create_spec_file(file_spec: Union[Dict, List]) -> SpecFile:
         file_options = file_spec.get('options', {})
         options = FileOptions().update(file_options)
 
+        alternates = file_spec.get('alternates', [])
+        if isinstance(alternates, str):
+            alternates = [alternates]
+        assert isinstance(alternates, list)
+
     elif isinstance(file_spec, list):  # legacy spec support
         file_name = file_spec[0]
         compile_commands = [f for f in file_spec[1:] if isinstance(f, str)]
@@ -72,11 +78,13 @@ def create_spec_file(file_spec: Union[Dict, List]) -> SpecFile:
         option_list = [opt for opt in file_spec[1:] if isinstance(opt, dict)]
         option_dict = {k: v for opt in option_list for k, v in opt.items()}
         options = FileOptions().update(option_dict)
+        alternates = []
 
     else:
         raise TypeError('Cannot parse "files:": incorrect data type for a file: {}'.format(type(file_spec)))
 
     return SpecFile(file_name=file_name,
+                    alternate_names=alternates,
                     compile_commands=compile_commands,
                     test_commands=test_commands,
                     options=options)

--- a/stograde/specs/supporting_file.py
+++ b/stograde/specs/supporting_file.py
@@ -4,6 +4,7 @@ from typing import Union, Dict, List
 
 @dataclass
 class SupportingFile:
+    """A file to include in the student's repo when checking the assignment"""
     file_name: str
     destination: str
 

--- a/test/formatters/results_for_tests.py
+++ b/test/formatters/results_for_tests.py
@@ -29,4 +29,8 @@ file_results = [FileResult(file_name='test_file.txt',
                 FileResult(file_name='truncated.txt',
                            contents='some tex',
                            truncated_after=8,
-                           last_modified='a modification time')]
+                           last_modified='a modification time'),
+                FileResult(file_name='misnamed.txt',
+                           actual_name='mn.txt',
+                           contents='more contents',
+                           last_modified='a time')]

--- a/test/formatters/results_for_tests.py
+++ b/test/formatters/results_for_tests.py
@@ -33,4 +33,5 @@ file_results = [FileResult(file_name='test_file.txt',
                 FileResult(file_name='misnamed.txt',
                            actual_name='mn.txt',
                            contents='more contents',
+                           other_files=['misnamed2.txt', 'Misnamed.text'],
                            last_modified='a time')]

--- a/test/formatters/test_html.py
+++ b/test/formatters/test_html.py
@@ -446,6 +446,17 @@ def test_add_styling():
 
 
 
+
+                                <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+
+                                <pre><code>
+        more contents
+                                </code></pre>
+
+
+
+
+
                                 <hr>
 
                             </div>
@@ -536,6 +547,17 @@ def test_format_assignment_html():
 
 
 
+
+        <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+
+        <pre><code>
+        more contents
+        </code></pre>
+
+
+
+
+
         <hr>
         ''')
 
@@ -620,6 +642,17 @@ def test_format_files_list():
         some tex
         </code></pre>
         <p><i>(truncated after 8 chars)</i></p>
+
+
+
+
+
+
+        <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+
+        <pre><code>
+        more contents
+        </code></pre>
 
 
 
@@ -744,6 +777,39 @@ def test_format_file_optional():
         <pre><code>
         yet_another_file.txt
         </code></pre>
+
+        ''')
+
+
+def test_format_file_truncated():
+    formatted = format_file(file_results[3])
+
+    assert '\n' + formatted == textwrap.dedent('''
+        <h2><code>truncated.txt</code> (a modification time)</h2>
+
+        <pre><code>
+        some tex
+        </code></pre>
+        <p><i>(truncated after 8 chars)</i></p>
+
+
+
+
+        ''')
+
+
+def test_format_file_alternate_name():
+    formatted = format_file(file_results[4])
+
+    assert '\n' + formatted == textwrap.dedent('''
+        <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+
+        <pre><code>
+        more contents
+        </code></pre>
+
+
+
 
         ''')
 

--- a/test/formatters/test_html.py
+++ b/test/formatters/test_html.py
@@ -448,6 +448,11 @@ def test_add_styling():
 
 
                                 <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+                                <i>Alternate files detected:</i>
+                                <ul>
+                                <li>misnamed2.txt</li>
+                                <li>Misnamed.text</li>
+                                </ul>
 
                                 <pre><code>
         more contents
@@ -549,6 +554,11 @@ def test_format_assignment_html():
 
 
         <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+        <i>Alternate files detected:</i>
+        <ul>
+        <li>misnamed2.txt</li>
+        <li>Misnamed.text</li>
+        </ul>
 
         <pre><code>
         more contents
@@ -649,6 +659,11 @@ def test_format_files_list():
 
 
         <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+        <i>Alternate files detected:</i>
+        <ul>
+        <li>misnamed2.txt</li>
+        <li>Misnamed.text</li>
+        </ul>
 
         <pre><code>
         more contents
@@ -803,6 +818,11 @@ def test_format_file_alternate_name():
 
     assert '\n' + formatted == textwrap.dedent('''
         <h2><code>mn.txt</code> (alternate name for <code>misnamed.txt</code>) (a time)</h2>
+        <i>Alternate files detected:</i>
+        <ul>
+        <li>misnamed2.txt</li>
+        <li>Misnamed.text</li>
+        </ul>
 
         <pre><code>
         more contents

--- a/test/formatters/test_markdown.py
+++ b/test/formatters/test_markdown.py
@@ -23,7 +23,7 @@ def test_format_assignment_markdown():
     assert formatted.assignment == 'lab1'
     assert formatted.student == 'student4'
     assert formatted.type is FormatType.MD
-    print(formatted.content)
+
     assert '\n' + formatted.content == textwrap.dedent('''
         # lab1 – student4
         First submission for lab1: 4/14/2020 16:04:05
@@ -77,6 +77,15 @@ def test_format_assignment_markdown():
         some tex
         ```
         *(truncated after 8 chars)*
+
+
+
+
+        ## mn.txt (alternate name for misnamed.txt) (a time)
+
+        ```txt
+        more contents
+        ```
 
 
 
@@ -164,6 +173,15 @@ def test_format_files_list():
         some tex
         ```
         *(truncated after 8 chars)*
+
+
+
+
+        ## mn.txt (alternate name for misnamed.txt) (a time)
+
+        ```txt
+        more contents
+        ```
 
 
         ''')
@@ -279,6 +297,35 @@ def test_format_file_optional():
         ```
         yet_another_file.txt
         ```
+        ''')
+
+
+def test_format_file_truncated():
+    formatted = format_file(file_results[3])
+
+    assert '\n' + formatted == textwrap.dedent('''
+        ## truncated.txt (a modification time)
+
+        ```txt
+        some tex
+        ```
+        *(truncated after 8 chars)*
+
+
+        ''')
+
+
+def test_format_file_alternate_name():
+    formatted = format_file(file_results[4])
+
+    assert '\n' + formatted == textwrap.dedent('''
+        ## mn.txt (alternate name for misnamed.txt) (a time)
+
+        ```txt
+        more contents
+        ```
+
+
         ''')
 
 

--- a/test/formatters/test_markdown.py
+++ b/test/formatters/test_markdown.py
@@ -82,6 +82,9 @@ def test_format_assignment_markdown():
 
 
         ## mn.txt (alternate name for misnamed.txt) (a time)
+        *Alternate files detected:*
+        - misnamed2.txt
+        - Misnamed.text
 
         ```txt
         more contents
@@ -178,6 +181,9 @@ def test_format_files_list():
 
 
         ## mn.txt (alternate name for misnamed.txt) (a time)
+        *Alternate files detected:*
+        - misnamed2.txt
+        - Misnamed.text
 
         ```txt
         more contents
@@ -320,6 +326,9 @@ def test_format_file_alternate_name():
 
     assert '\n' + formatted == textwrap.dedent('''
         ## mn.txt (alternate name for misnamed.txt) (a time)
+        *Alternate files detected:*
+        - misnamed2.txt
+        - Misnamed.text
 
         ```txt
         more contents

--- a/test/process_assignment/test_process_assignment.py
+++ b/test/process_assignment/test_process_assignment.py
@@ -20,8 +20,8 @@ _dir = os.path.dirname(os.path.realpath(__file__))
 def test_process_assignment(datafiles):
     student_result = StudentResult('student1')
     spec = Spec('hw1', 'hw1', architecture=None,
-                files=[SpecFile('a_file.txt', [], [], FileOptions()),
-                       SpecFile('b_file.txt', [], [], FileOptions())])
+                files=[SpecFile('a_file.txt', [], [], [], FileOptions()),
+                       SpecFile('b_file.txt', [], [], [], FileOptions())])
 
     with chdir(str(datafiles)):
         git('init')
@@ -101,17 +101,19 @@ def test_process_assignment_ci(mock_function):
 
 def test_remove_execs(tmpdir):
     spec = Spec('hw2', 'hw2', architecture=None,
-                files=[SpecFile('a_file.txt', [], [], FileOptions()),
-                       SpecFile('file', [], [], FileOptions()),
-                       SpecFile('test.cpp', [], [], FileOptions())])
+                files=[SpecFile('a_file.txt', [], [], [], FileOptions()),
+                       SpecFile('file', [], [], [], FileOptions()),
+                       SpecFile('test.cpp', ['Test.cpp', 'TEST.cpp'], [], [], FileOptions())])
 
     with tmpdir.as_cwd():
         touch('non_exec_file.txt')
         touch('file.exec')
         touch('non_spec_exec.exec')
         touch('test.cpp.exec')
+        touch('Test.cpp.exec')
 
-        assert set(os.listdir('.')) == {'non_exec_file.txt', 'file.exec', 'non_spec_exec.exec', 'test.cpp.exec'}
+        assert set(os.listdir('.')) == {'non_exec_file.txt', 'file.exec', 'non_spec_exec.exec',
+                                        'test.cpp.exec', 'Test.cpp.exec'}
 
         remove_execs(spec)
 

--- a/test/process_file/fixtures/another_file.txt
+++ b/test/process_file/fixtures/another_file.txt
@@ -1,0 +1,1 @@
+other contents

--- a/test/process_file/test_process_file.py
+++ b/test/process_file/test_process_file.py
@@ -20,7 +20,7 @@ _dir = os.path.dirname(os.path.realpath(__file__))
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures'))
 def test_get_file_success(datafiles):
-    spec = SpecFile('a_file.txt', [], [], FileOptions())
+    spec = SpecFile('a_file.txt', [], [], [], FileOptions())
     result = FileResult(file_name='a_file.txt')
 
     with chdir(str(datafiles)):
@@ -47,9 +47,9 @@ def test_get_file_success(datafiles):
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures'))
 def test_get_file_hide_contents(datafiles):
-    spec = SpecFile('a_file.txt', [], [], FileOptions(hide_contents=True,
-                                                      optional=True,
-                                                      compile_optional=True))
+    spec = SpecFile('a_file.txt', [], [], [], FileOptions(hide_contents=True,
+                                                          optional=True,
+                                                          compile_optional=True))
     result = FileResult(file_name='a_file.txt')
 
     with chdir(str(datafiles)):
@@ -76,7 +76,7 @@ def test_get_file_hide_contents(datafiles):
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures'))
 def test_get_file_truncated_contents(datafiles):
-    spec = SpecFile('a_file.txt', [], [], FileOptions(truncate_contents=4))
+    spec = SpecFile('a_file.txt', [], [], [], FileOptions(truncate_contents=4))
     result = FileResult(file_name='a_file.txt')
 
     with chdir(str(datafiles)):
@@ -103,7 +103,7 @@ def test_get_file_truncated_contents(datafiles):
 
 @pytest.mark.datafiles(os.path.join(_dir, 'fixtures'))
 def test_get_file_missing(datafiles):
-    spec = SpecFile('b_file.txt', [], [], FileOptions(optional=True))
+    spec = SpecFile('b_file.txt', [], [], [], FileOptions(optional=True))
     result = FileResult(file_name='b_file.txt')
 
     with chdir(str(datafiles)):

--- a/test/process_file/test_process_file.py
+++ b/test/process_file/test_process_file.py
@@ -69,7 +69,7 @@ def test_get_file_alternate(datafiles):
     assert not result.test_results
     assert result.file_missing is False
     assert result.last_modified == 'Tue Apr 21 12:28:03 2020 -0500'
-    assert not result.other_files
+    assert result.other_files == ['a_file.txt']
     assert result.optional is False
     assert result.compile_optional is False
 
@@ -495,7 +495,7 @@ def test_process_file_alternate(datafiles):
                                               truncated_after=None)]
     assert result.file_missing is False
     assert result.last_modified == 'Tue Apr 21 12:28:03 2020 -0500'
-    assert not result.other_files
+    assert result.other_files == ['bad.cpp']
     assert result.optional is False
     assert result.compile_optional is False
 

--- a/test/specs/test_spec_file.py
+++ b/test/specs/test_spec_file.py
@@ -98,6 +98,28 @@ def test_create_spec_file_with_tests_list():
     check_file_options_has_defaults(new_file.options)
 
 
+def test_create_spec_file_with_alternates_str():
+    new_file = create_spec_file({
+        'file': 'test_file5-1.txt',
+        'alternates': 'test_file5-2.txt',
+    })
+
+    assert new_file.file_name == 'test_file5-1.txt'
+    assert new_file.alternate_names == ['test_file5-2.txt']
+    check_file_options_has_defaults(new_file.options)
+
+
+def test_create_spec_file_with_alternates_list():
+    new_file = create_spec_file({
+        'file': 'test_file5-3.txt',
+        'alternates': ['test_file5-4.txt', 'test_file5-5.txt'],
+    })
+
+    assert new_file.file_name == 'test_file5-3.txt'
+    assert new_file.alternate_names == ['test_file5-4.txt', 'test_file5-5.txt']
+    check_file_options_has_defaults(new_file.options)
+
+
 def test_create_spec_file_with_compile_optional():
     new_file = create_spec_file({
         'file': 'test_file6.txt',

--- a/test/student/test_record_student.py
+++ b/test/student/test_record_student.py
@@ -21,9 +21,9 @@ _dir = os.path.dirname(os.path.realpath(__file__))
 def test_record_student(datafiles):
     student_result = StudentResult('student1')
     specs = [Spec('hw1', 'hw1', architecture=None,
-                  files=[SpecFile('a_file.txt', [], [], FileOptions())]),
+                  files=[SpecFile('a_file.txt', [], [], [], FileOptions())]),
              Spec('hw2', 'hw2', architecture=None,
-                  files=[SpecFile('b_file.txt', [], [], FileOptions())])]
+                  files=[SpecFile('b_file.txt', [], [], [], FileOptions())])]
 
     with chdir(str(datafiles)):
         with chdir('student1'):


### PR DESCRIPTION
Allow files to have alternative names in case the student misnames their file

- If the file cannot be found, any alternate names will be searched for
- If alternate names are specified and a file is found, other alternate names will be searched for and, if found, will be listed to alert the TA that multiple files could be the one the student intended to turn in